### PR TITLE
taxi_streaming example: Minor code-file fixes

### DIFF
--- a/taxi_streaming/create_random_driver_data.py
+++ b/taxi_streaming/create_random_driver_data.py
@@ -33,5 +33,3 @@ for x in range (1,1000):
 		status = Statuses [rnd_status]
                 print ("%d,2017-12-05 09:00:00.050000000,%f,%fi,%s"  %(rnd_driver,long,lat,status))
 
-
-

--- a/taxi_streaming/create_taxi_stream.sh
+++ b/taxi_streaming/create_taxi_stream.sh
@@ -11,4 +11,3 @@ curl  -X PUT \
      --data '{"ShardCount": 12, "RetentionPeriodHours": 1}' \
      http://127.0.0.1:8081/1/$STREAM_NAME/
 
-

--- a/taxi_streaming/create_taxi_stream.sh
+++ b/taxi_streaming/create_taxi_stream.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NGINX_IP=‘127.0.0.1’
+NGINX_IP='127.0.0.1'
 
 STREAM_NAME=taxi_example/driver_stream
 


### PR DESCRIPTION
- Replace non-standard single-quote Unicode characters `‘` (`â€˜`) and `’` (`â€™`) with `'`.
- (Minor cosmetics) Remove redundant empty lines at the end of files.