### PR TITLE
taxi_streaming: replace container ID with name + set with DF v3io:// table path

### DIFF
--- a/taxi_streaming/consume_drivers_stream_data.py
+++ b/taxi_streaming/consume_drivers_stream_data.py
@@ -2,13 +2,13 @@ from pyspark.sql import SparkSession
 from pyspark.streaming import StreamingContext
 from v3io.spark.streaming import *
 
-# Data-container ID
-CONTAINER_ID = 1  # assumes a default container with ID 1
+# Data-container name
+CONTAINER_NAME="bigdata"
 
 # Path to the taxi_streaming example directory within the container
 EXAMPLE_PATH = "/taxi_example/"
 # NoSQL tables Path
-NOSQL_TABLES_PATH = EXAMPLE_PATH
+NOSQL_TABLES_PATH = "v3io://" + CONTAINER_NAME + EXAMPLE_PATH
 # Stream container-directory path
 STREAM_PATH = EXAMPLE_PATH + "driver_stream"
 
@@ -27,7 +27,6 @@ def archive(rdd):
             .format("io.iguaz.v3io.spark.sql.kv") \
             .mode("overwrite") \
             .option("Key", "driver") \
-            .option("container-id", CONTAINER_ID) \
             .save("{0}/{1}".format(NOSQL_TABLES_PATH, "driver_kv/"))
 
         # Group the driver ride-status data for all drivers, and count the
@@ -40,7 +39,6 @@ def archive(rdd):
             .format("io.iguaz.v3io.spark.sql.kv") \
             .mode("overwrite") \
             .option("Key", "status") \
-            .option("container-id", CONTAINER_ID) \
             .save("{0}/{1}".format(NOSQL_TABLES_PATH, "driver_summary/"))
 
 # Create a Spark session
@@ -51,7 +49,7 @@ spark = SparkSession.builder \
 # Create a Spark streaming context with a 10-seconds micro-batch interval
 ssc = StreamingContext(spark.sparkContext, 10)
 # Configure the platform stream's parent data container
-v3ioConfig = {"container-id": CONTAINER_ID}
+v3ioConfig = {"container-alias": CONTAINER_NAME}
 # Map the platform stream to a Spark input stream using the platform's
 # Spark-Streaming Integration API
 stream = V3IOUtils.createDirectStream(ssc, [STREAM_PATH], v3ioConfig)

--- a/taxi_streaming/create_drivers_stream.sh
+++ b/taxi_streaming/create_drivers_stream.sh
@@ -4,8 +4,8 @@
 NGINX_IP="127.0.0.1"
 # Port number of the platform's web-gateway service
 NGINX_PORT="8081"
-# Data-container ID
-CONTAINER_ID=1  # assumes a default container with ID 1
+# Data-container name
+CONTAINER_NAME="bigdata"
 # Stream container-directory path
 STREAM_PATH="/taxi_example/driver_stream"
 # Stream shard count - the number of shards into which to divide the stream
@@ -22,5 +22,5 @@ curl -X PUT \
     --header "X-v3io-function: CreateStream" \
     --header "Cache-Control: no-cache" \
     --data "{'ShardCount': ${NUM_SHARDS}, 'RetentionPeriodHours': ${RETENTION_PERIOD}}" \
-    http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_ID}${STREAM_PATH}/
+    http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_NAME}${STREAM_PATH}/
 

--- a/taxi_streaming/delete_stream.sh
+++ b/taxi_streaming/delete_stream.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Data-container ID
-CONTAINER_ID=1  # assumes a default container with ID 1
+# Data-container name
+CONTAINER_NAME="bigdata"
 # IP address of the platform's web-gateway service
 NGINX_IP="127.0.0.1"
 # Port number of the platform's web-gateway service
@@ -14,10 +14,10 @@ NUM_SHARDS=12
 # Delete the stream by removing its container directory
 for i in `eval echo {0..${NUM_SHARDS}}`
 do
-   echo "curl -v -XDELETE http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_ID}/${STREAM_PATH}/$i"
-   curl -v -XDELETE http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_ID}/${STREAM_PATH}/$i
+   echo "curl -v -XDELETE http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_NAME}/${STREAM_PATH}/$i"
+   curl -v -XDELETE http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_NAME}/${STREAM_PATH}/$i
 done
 
-echo "Deleting the ${STREAM_PATH} stream from container #${CONTAINER_ID} ..."
-curl -v -XDELETE http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_ID}${STREAM_PATH}/
+echo "Deleting the ${STREAM_PATH} stream from container ${CONTAINER_NAME} ..."
+curl -v -XDELETE http://${NGINX_IP}:${NGINX_PORT}/${CONTAINER_NAME}${STREAM_PATH}/
 

--- a/taxi_streaming/stream_drivers_data.py
+++ b/taxi_streaming/stream_drivers_data.py
@@ -7,8 +7,8 @@ import requests
 import time
 import sys
 
-# Data-container ID
-CONTAINER_ID = 1  # assumes a default container with ID 1
+# Data-container name
+CONTAINER_NAME="bigdata"
 # IP address of the platform's web-gateway service
 NGINX_IP = "127.0.0.1"
 # Port number of the platform's web-gateway service
@@ -24,10 +24,10 @@ INPUT_FILE = str(sys.argv[1])
 
 
 # Create the PutRecords request URL with the platform's web-gateway host name
-# or IP address and port number, the container ID, and the stream path
+# or IP address and port number, the container name, and the stream path
 def get_stream_url():
     return "http://{0}:{1}/{2}{3}/" \
-        .format(NGINX_IP, NGINX_PORT, CONTAINER_ID, STREAM_PATH)
+        .format(NGINX_IP, NGINX_PORT, CONTAINER_NAME, STREAM_PATH)
 
 
 # Create the PutRecords request headers


### PR DESCRIPTION
- Use the container name/alias instead of the container ID.
- In Spark DataFrames, set the container name as part of the table path that is passed to `save`, using a `v3io://<container name>/...` path, instead of using `option("container-alias", CONTAINER_NAME)` (per Golan's guidelines).

@NirSe  Please merge. (Tested)