### PR TITLE
MERGE PR #93 to 1.9: [IG-7946] taxi_streaming: use v3io:// createDirectStream.streamNames paths

### DIFF
--- a/taxi_streaming/README.md
+++ b/taxi_streaming/README.md
@@ -271,11 +271,12 @@ A Spark `StreamingContext` object with a 10-seconds micro-batch interval is crea
 ssc = StreamingContext(spark.sparkContext, 10)
 ```
 
-The `V3IIOUtils.CreateDirectStream` method of the platform's Spark-Streaming Integration API is used to create an `InputDStream` Spark input-stream object (`stream`) that maps the Spark streaming context (`ssc`) to the **taxi_streaming_example/drivers_stream** platform stream (`STREAM_PATH`) of the "bigdata" container (`$CONTAINER_NAME`):
+The `V3IIOUtils.CreateDirectStream` method of the platform's Spark-Streaming Integration API is used to create an `InputDStream` Spark input-stream object (`stream`) that maps the Spark streaming context (`ssc`) to the **taxi_streaming_example/drivers_stream** platform stream (`STREAM_PATH`) of the "bigdata" container (`$CONTAINER_NAME`).
+The stream path is passed to the `createDirectStream` method within its `streamNames` parameter as a fully qualified path of the format <nobr>`v3io://<container name>/<stream-directory path within the container>`</nobr> (see `$V3IO_STREAM_PATH`):
 
 ```python
-v3ioConfig = {"container-id": CONTAINER_NAME}
-stream = V3IOUtils.createDirectStream(ssc, v3ioConfig, [STREAM_PATH])
+v3ioConfig = {}
+stream = V3IOUtils.createDirectStream(ssc, v3ioConfig, [V3IO_STREAM_PATH])
 ```
 
 The Spark input stream (`stream`) is assigned the local `archive` data-consumption function as its Resilient Distributed Dataset (RDD) handler.

--- a/taxi_streaming/consume_drivers_stream_data.py
+++ b/taxi_streaming/consume_drivers_stream_data.py
@@ -10,8 +10,10 @@ CONTAINER_NAME = "bigdata"
 EXAMPLE_PATH = "/taxi_streaming_example/"
 # Parent tables directory
 NOSQL_TABLES_PATH = "v3io://" + CONTAINER_NAME + EXAMPLE_PATH
-# Stream directory
+# Stream path within the parent container directory
 STREAM_PATH = EXAMPLE_PATH + "drivers_stream"
+# Fully qualified v3io stream path
+V3IO_STREAM_PATH = "v3io://" + CONTAINER_NAME + STREAM_PATH
 # NoSQL drivers-data table
 DRIVERS_TABLE_PATH = NOSQL_TABLES_PATH + "/drivers_table/" 
 # NoSQL drivers ride-status summary table
@@ -50,13 +52,11 @@ spark = SparkSession.builder \
 
 # Create a Spark streaming context with a 10-seconds micro-batch interval
 ssc = StreamingContext(spark.sparkContext, 10)
-
-# Set the container identifier to the configured container name
-v3ioConfig = {"container-id": CONTAINER_NAME}
-
+# Do not set any configuration properties for the stream
+v3ioConfig = {}
 # Map the platform stream to a Spark input stream using the platform's
 # Spark-Streaming Integration API
-stream = V3IOUtils.createDirectStream(ssc, v3ioConfig, [STREAM_PATH])
+stream = V3IOUtils.createDirectStream(ssc, v3ioConfig, [V3IO_STREAM_PATH])
 
 # Assign the archive stream-data consumption function as the stream's
 # Resilient Distributed Dataset (RDD) handler


### PR DESCRIPTION
Merge back relevant taxi_streaming changes reverted in commit d131203 (consume_drivers_stream_data.py) & comit 6eca2b5 (README.md) changes: configure the stream's parent container by using fully qualified v3io:// stream paths in the createDirectStream streamNames parameter rather than configuring the container-id property in the v3ioParams parameter.